### PR TITLE
Make log contexts append instead of overriding.

### DIFF
--- a/serilog-utilities-concurrent-correlator-tests/CorrelationLogContextTests.cs
+++ b/serilog-utilities-concurrent-correlator-tests/CorrelationLogContextTests.cs
@@ -88,5 +88,25 @@ namespace Serilog.Utilities.ConcurrentCorrelator.Tests
                 .Should()
                 .NotContain(logEvent => logEvent.MessageTemplate.Text == "Message template.");
         }
+
+        [Fact]
+        public void A_CorrelationLogContext_within_a_CorrelationLogContext_adds_an_additional_CorrelationLogContext_to_LogEvents()
+        {
+            using (var outerCorrelationLogContext = new CorrelationLogContext())
+            {
+                using (var innerCorrelationLogContext = new CorrelationLogContext())
+                {
+                    Log.Logger.Information("Message template.");
+
+                    SerilogLogEvents.Bag.WithCorrelationLogContextGuid(innerCorrelationLogContext.Guid)
+                        .Should()
+                        .OnlyContain(logEvent => logEvent.MessageTemplate.Text == "Message template.");
+
+                    SerilogLogEvents.Bag.WithCorrelationLogContextGuid(outerCorrelationLogContext.Guid)
+                        .Should()
+                        .OnlyContain(logEvent => logEvent.MessageTemplate.Text == "Message template.");
+                }
+            }
+        }
     }
 }

--- a/serilog-utilities-concurrent-correlator-tests/EnumerableOfLogEventExtensionsTests.cs
+++ b/serilog-utilities-concurrent-correlator-tests/EnumerableOfLogEventExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace Serilog.Utilities.ConcurrentCorrelator.Tests
                 new MessageTemplate("Message template.", Enumerable.Empty<MessageTemplateToken>()),
                 new List<LogEventProperty>
                 {
-                    new LogEventProperty("CorrelationGuid", new ScalarValue(correlationGuid))
+                    new LogEventProperty(correlationGuid.ToString(), new ScalarValue(null))
                 });
         }
 

--- a/serilog-utilities-concurrent-correlator/CorrelationLogContext.cs
+++ b/serilog-utilities-concurrent-correlator/CorrelationLogContext.cs
@@ -10,7 +10,7 @@ namespace Serilog.Utilities.ConcurrentCorrelator
         public CorrelationLogContext()
         {
             Guid = Guid.NewGuid();
-            this.context = LogContext.PushProperty("CorrelationGuid", Guid);
+            this.context = LogContext.PushProperty(Guid.ToString(), null);
         }
 
         public Guid Guid { get; }

--- a/serilog-utilities-concurrent-correlator/EnumerableOfLogEventExtensions.cs
+++ b/serilog-utilities-concurrent-correlator/EnumerableOfLogEventExtensions.cs
@@ -10,20 +10,7 @@ namespace Serilog.Utilities.ConcurrentCorrelator
         public static IEnumerable<LogEvent> WithCorrelationLogContextGuid(
             this IEnumerable<LogEvent> logEvents, Guid correlationLogContextGuid)
         {
-            return logEvents.Where(
-                logEvent =>
-                {
-                    if (logEvent.Properties.ContainsKey("CorrelationGuid"))
-                    {
-                        Guid result;
-
-                        Guid.TryParse(logEvent.Properties["CorrelationGuid"].ToString(), out result);
-
-                        return result == correlationLogContextGuid;
-                    }
-
-                    return false;
-                });
+            return logEvents.Where(logEvent => logEvent.Properties.ContainsKey(correlationLogContextGuid.ToString()));
         }
     }
 }


### PR DESCRIPTION
Changed it so that we only use the key of the property to distinguish a log context.